### PR TITLE
Fix inference scheduler call

### DIFF
--- a/Inference/sample.py
+++ b/Inference/sample.py
@@ -78,7 +78,7 @@ def sample(model, scheduler, train_config, diffusion_model_config,
             noise_pred = noise_pred_cond
         
         # Use scheduler to get x0 and xt-1
-        xt, x0_pred = scheduler.sample_prev_timestep(xt, noise_pred, torch.as_tensor(i).to(device))
+        xt, x0_pred = scheduler.sample_from_prev_timestep(xt, noise_pred, torch.as_tensor(i).to(device))
 
         ims = xt
         


### PR DESCRIPTION
## Summary
- call the correct `sample_from_prev_timestep` method in the inference script

## Testing
- `python -m py_compile Inference/sample.py Model/NoiseScheduler.py Training/train.py Utils/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6841962d0f508325be2709b818d688f4