### PR TITLE
Add unit tests for diffusion utils

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -56,3 +56,4 @@ typing_extensions==4.12.0
 urllib3==2.2.1
 wcwidth==0.2.13
 zipp==3.19.0
+pytest==8.3.5

--- a/tests/test_diffusion_utils.py
+++ b/tests/test_diffusion_utils.py
@@ -1,0 +1,23 @@
+import torch
+from Utils.diffusion_utils import drop_text_condition, drop_image_condition
+
+
+def test_drop_text_condition_full_drop():
+    batch, tokens, dim = 2, 3, 4
+    text_embed = torch.randn(batch, tokens, dim)
+    im = torch.randn(batch, 3, 32, 32)
+    empty = torch.randn(1, tokens, dim)
+
+    out = drop_text_condition(text_embed.clone(), im, empty, 1.0)
+    expected = empty[0].expand_as(text_embed)
+    assert torch.allclose(out, expected)
+
+
+def test_drop_image_condition_full_drop():
+    batch, dim = 3, 5
+    image_embed = torch.randn(batch, dim)
+    empty = torch.randn(1, dim)
+
+    out = drop_image_condition(image_embed.clone(), empty, 1.0)
+    expected = empty[0].expand_as(image_embed)
+    assert torch.allclose(out, expected)


### PR DESCRIPTION
## Summary
- add pytest-based unit tests for `drop_text_condition` and `drop_image_condition`
- include pytest dependency in `requirement.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6841974bb4e0832591c0b223ede02f8f